### PR TITLE
Resolve exceptions at end of raid caused by despawning bots

### DIFF
--- a/Donuts.csproj
+++ b/Donuts.csproj
@@ -137,6 +137,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="MatchEndPlayerDisposePatch.cs" />
     <Compile Include="PatchBodySound.cs" />
     <Compile Include="Component.cs" />
     <Compile Include="ConfigurationManagerAttributes.cs" />

--- a/MatchEndPlayerDisposePatch.cs
+++ b/MatchEndPlayerDisposePatch.cs
@@ -1,0 +1,45 @@
+﻿using Aki.Reflection.Patching;
+using Aki.Reflection.Utils;
+using EFT;
+using EFT.AssetsManager;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using UnityEngine;
+
+namespace dvize.Donuts
+{
+    internal class MatchEndPlayerDisposePatch : ModulePatch
+    {
+        protected override MethodBase GetTargetMethod()
+        {
+            // Method used by SPT for finding BaseLocalGame
+            return PatchConstants.EftTypes.Single(x => x.Name == "LocalGame").BaseType // BaseLocalGame
+                .GetMethod("smethod_3", BindingFlags.FlattenHierarchy | BindingFlags.NonPublic | BindingFlags.Static);
+        }
+
+        [PatchPrefix]
+        private static bool PatchPrefix(IDictionary<string, Player> players)
+        {
+            foreach (Player player in players.Values)
+            {
+                if (player != null)
+                {
+                    try
+                    {
+                        player.Dispose();
+                        AssetPoolObject.ReturnToPool(player.gameObject, true);
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.LogException(ex);
+                    }
+                }
+            }
+            players.Clear();
+
+            return false;
+        }
+    }
+}

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -355,6 +355,7 @@ namespace Donuts
             //Patches
             new NewGamePatch().Enable();
             new PatchBodySound().Enable();
+            new MatchEndPlayerDisposePatch().Enable();
         }
 
         private void Update()


### PR DESCRIPTION
Does what the title says, patches smethod_3 to add a null check before trying to dispose of player objects that may already be disposed of