### PR TITLE
Fix enemy choice once bots have been despawned

### DIFF
--- a/Component.cs
+++ b/Component.cs
@@ -70,6 +70,7 @@ namespace Donuts
 
         public void Awake()
         {
+            botSpawnerClass = Singleton<IBotGame>.Instance.BotsController.BotSpawner;
             methodCache = new Dictionary<string, MethodInfo>();
 
             // Retrieve displayMessageNotification MethodInfo
@@ -86,11 +87,34 @@ namespace Donuts
             {
                 methodCache[methodInfo.Name] = methodInfo;
             }
+
+            // Remove despawned bots from bot EnemyInfos list.
+            botSpawnerClass.OnBotRemoved += removedBot =>
+            {
+                // Clear the enemy list, and memory about the main player
+                removedBot.Memory.DeleteInfoAboutEnemy(gameWorld.MainPlayer);
+                removedBot.EnemiesController.EnemyInfos.Clear();
+
+                // Loop through the rest of the bots on the map, andd clear this bot from its memory/group info
+                foreach (var player in gameWorld.AllAlivePlayersList)
+                {
+                    if (!player.IsAI)
+                    {
+                        continue;
+                    }
+
+                    // Clear the bot from all other bots enemy info
+                    var botOwner = player.AIData.BotOwner;
+                    botOwner.Memory.DeleteInfoAboutEnemy(removedBot);
+                    botOwner.BotsGroup.RemoveInfo(removedBot);
+                    botOwner.BotsGroup.RemoveEnemy(removedBot);
+                    botOwner.BotsGroup.RemoveAlly(removedBot);
+                }
+            };
         }
+
         private void Start()
         {
-            botSpawnerClass = Singleton<IBotGame>.Instance.BotsController.BotSpawner;
-
             // setup the rest of donuts for the selected folder
             InitializeStaticVariables();
             maplocation = gameWorld.MainPlayer.Location.ToLower();

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -361,6 +361,8 @@ namespace Donuts
 
             //Patches
             new NewGamePatch().Enable();
+            new BotGroupAddEnemyPatch().Enable();
+            new BotMemoryAddEnemyPatch().Enable();
             new PatchBodySound().Enable();
             new MatchEndPlayerDisposePatch().Enable();
             new PatchStandbyTeleport().Enable();
@@ -646,6 +648,38 @@ namespace Donuts
         [PatchPrefix]
         public static void PatchPrefix() => DonutComponent.Enable();
     }
+
+    // Don't add invalid enemies
+    internal class BotGroupAddEnemyPatch : ModulePatch
+    {
+        protected override MethodBase GetTargetMethod() => typeof(BotGroupClass).GetMethod("AddEnemy");
+        [PatchPrefix]
+        public static bool PatchPrefix(IAIDetails person)
+        {
+            if (person == null || (person.IsAI && person.AIData?.BotOwner?.GetPlayer == null))
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+
+    internal class BotMemoryAddEnemyPatch : ModulePatch
+    {
+        protected override MethodBase GetTargetMethod() => typeof(BotMemoryClass).GetMethod("AddEnemy");
+        [PatchPrefix]
+        public static bool PatchPrefix(IAIDetails enemy)
+        {
+            if (enemy == null || (enemy.IsAI && enemy.AIData?.BotOwner?.GetPlayer == null))
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+
     internal class Folder
     {
         public string Name


### PR DESCRIPTION
- Add a patch to BotGroupClass.AddEnemy and BotMemory.AddEnemy that excludes null enemies
- Hook the BotSpawner.OnBotRemoved event to clear removed bot memory, and group enemy information