### PR TITLE
Add a new DependencyChecker

### DIFF
--- a/DependencyChecker.cs
+++ b/DependencyChecker.cs
@@ -1,0 +1,113 @@
+﻿using BepInEx;
+using BepInEx.Bootstrap;
+using BepInEx.Configuration;
+using BepInEx.Logging;
+using System;
+using UnityEngine;
+
+namespace Donuts
+{
+    internal class DependencyChecker
+    {
+        /// <summary>
+        /// Check that all of the BepInDependency entries for the given pluginType are available and instantiated. This allows a
+        /// plugin to validate that its dependent plugins weren't disabled post-dependency check (Such as for the wrong EFT version)
+        /// </summary>
+        /// <param name="Logger"></param>
+        /// <param name="Info"></param>
+        /// <param name="pluginType"></param>
+        /// <param name="Config"></param>
+        /// <returns></returns>
+        public static bool ValidateDependencies(ManualLogSource Logger, PluginInfo Info, Type pluginType, ConfigFile Config = null)
+        {
+            var noVersion = new Version("0.0.0");
+            var dependencies = pluginType.GetCustomAttributes(typeof(BepInDependency), true) as BepInDependency[];
+
+            foreach (var dependency in dependencies)
+            {
+                PluginInfo pluginInfo;
+                if (!Chainloader.PluginInfos.TryGetValue(dependency.DependencyGUID, out pluginInfo))
+                {
+                    pluginInfo = null;
+                }
+
+                // If the plugin isn't found, or the instance isn't enabled, it means the required plugin failed to load
+                if (pluginInfo == null || pluginInfo.Instance?.enabled == false)
+                {
+                    string dependencyName = pluginInfo?.Metadata.Name ?? dependency.DependencyGUID;
+                    string dependencyVersion = "";
+                    if (dependency.MinimumVersion > noVersion)
+                    {
+                        dependencyVersion = $" v{dependency.MinimumVersion}";
+                    }
+
+                    string errorMessage = $"ERROR: This version of {Info.Metadata.Name} v{Info.Metadata.Version} depends on {dependencyName}{dependencyVersion}, but it was not loaded.";
+                    Logger.LogError(errorMessage);
+                    Chainloader.DependencyErrors.Add(errorMessage);
+
+                    if (Config != null)
+                    {
+                        // This results in a bogus config entry in the BepInEx config file for the plugin, but it shouldn't hurt anything
+                        // We leave the "section" parameter empty so there's no section header drawn
+                        Config.Bind("", "MissingDeps", "", new ConfigDescription(
+                            errorMessage, null, new ConfigurationManagerAttributes
+                            {
+                                CustomDrawer = ErrorLabelDrawer,
+                                ReadOnly = true,
+                                HideDefaultButton = true,
+                                HideSettingName = true,
+                                Category = null
+                            }
+                        ));
+                    }
+
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        static void ErrorLabelDrawer(ConfigEntryBase entry)
+        {
+            GUIStyle styleNormal = new GUIStyle(GUI.skin.label);
+            styleNormal.wordWrap = true;
+            styleNormal.stretchWidth = true;
+
+            GUIStyle styleError = new GUIStyle(GUI.skin.label);
+            styleError.stretchWidth = true;
+            styleError.alignment = TextAnchor.MiddleCenter;
+            styleError.normal.textColor = Color.red;
+            styleError.fontStyle = FontStyle.Bold;
+
+            // General notice that we're the wrong version
+            GUILayout.BeginVertical();
+            GUILayout.Label(entry.Description.Description, styleNormal, new GUILayoutOption[] { GUILayout.ExpandWidth(true) });
+
+            // Centered red disabled text
+            GUILayout.Label("Plugin has been disabled!", styleError, new GUILayoutOption[] { GUILayout.ExpandWidth(true) });
+            GUILayout.EndVertical();
+        }
+
+#pragma warning disable 0169, 0414, 0649
+        internal sealed class ConfigurationManagerAttributes
+        {
+            public bool? ShowRangeAsPercent;
+            public System.Action<BepInEx.Configuration.ConfigEntryBase> CustomDrawer;
+            public CustomHotkeyDrawerFunc CustomHotkeyDrawer;
+            public delegate void CustomHotkeyDrawerFunc(BepInEx.Configuration.ConfigEntryBase setting, ref bool isCurrentlyAcceptingInput);
+            public bool? Browsable;
+            public string Category;
+            public object DefaultValue;
+            public bool? HideDefaultButton;
+            public bool? HideSettingName;
+            public string Description;
+            public string DispName;
+            public int? Order;
+            public bool? ReadOnly;
+            public bool? IsAdvanced;
+            public System.Func<object, string> ObjToStr;
+            public System.Func<string, object> StrToObj;
+        }
+    }
+}

--- a/Donuts.csproj
+++ b/Donuts.csproj
@@ -142,6 +142,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DependencyChecker.cs" />
     <Compile Include="patches\PatchBodySound.cs" />
     <Compile Include="patches\PatchStandbyTeleport.cs" />
     <Compile Include="patches\MatchEndPlayerDisposePatch.cs" />

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -107,6 +108,11 @@ namespace Donuts
 
         private void Awake()
         {
+            if (!DependencyChecker.ValidateDependencies(Logger, Info, this.GetType(), Config))
+            {
+                throw new Exception($"Missing Dependencies");
+            }
+
             //Main Settings
             PluginEnabled = Config.Bind(
                 "1. Main Settings",


### PR DESCRIPTION
This adds a new DependencyChecker class that will check for runtime-disabled dependency plugins (Such as SAIN disabling itself due to an invalid EFT version), and disable Donuts if any of its dependencies are disabled. 

This utilizes the existing BepInDependency attributes, so no further management of dependencies is required

To test, install all of the dependencies of Donuts in a 3.7.1 install, including a 3.7.0 copy of SAIN. This will trigger SAIN to fail to load, which will now cause Donuts to refuse to load, instead of Donuts loading anyways and potentially causing issues.

1) Extract BigBrain and Waypoints for 3.7.1 into your 3.7.1 install
2) Extract SAIN for 3.7.0 into your 3.7.1 install
3) Build this branch of Donuts into your 3.7.1 install
4) Start the client

You should get a prompt in the bottom right that 1 plugin has failed to load (SAIN doesn't currently piggyback on the error messaging system that SPT uses for displaying errors, so it doesn't get listed). The in-game console (And BepInEx log) should both show that Donuts failed to load due to SAIN. The F12 settings menu for Donuts should also show that the plugin is disabled when you try to expand it, indicating the SAIN dependency is missing